### PR TITLE
Add favorite page and reflect count of favorite

### DIFF
--- a/site/src/commonMain/kotlin/bbee/developer/jp/assemble_pc/models/Assembly.kt
+++ b/site/src/commonMain/kotlin/bbee/developer/jp/assemble_pc/models/Assembly.kt
@@ -14,6 +14,7 @@ data class Assembly(
     val published: Boolean,
     val publishedDate: String,
     val assemblyDetails: List<AssemblyDetail>,
+    val favoriteCount: Int,
 )
 
 @Serializable

--- a/site/src/jsMain/kotlin/bbee/developer/jp/assemble_pc/components/widgets/AssemblyCard.kt
+++ b/site/src/jsMain/kotlin/bbee/developer/jp/assemble_pc/components/widgets/AssemblyCard.kt
@@ -49,7 +49,10 @@ import org.jetbrains.compose.web.css.px
 fun AssemblyCard(
     breakpoint: Breakpoint,
     assembly: Assembly,
-    ownerName: String = assembly.ownerName ?: "(NO NAME)"
+    isMyFavorite: Boolean = false,
+    ownerName: String = assembly.ownerName ?: "(NO NAME)",
+    onFavoriteClick: (Boolean) -> Unit = {},
+    onReferenceClick: () -> Unit = {}
 ) {
     Box(
         modifier = Modifier
@@ -60,7 +63,10 @@ fun AssemblyCard(
         AssemblyCardContent(
             breakpoint = breakpoint,
             assembly = assembly,
-            ownerName = ownerName
+            isMyFavorite = isMyFavorite,
+            ownerName = ownerName,
+            onFavoriteClick = onFavoriteClick,
+            onReferenceClick = onReferenceClick
         )
     }
 }
@@ -69,7 +75,10 @@ fun AssemblyCard(
 fun AssemblyCardContent(
     breakpoint: Breakpoint,
     assembly: Assembly,
+    isMyFavorite: Boolean,
     ownerName: String,
+    onFavoriteClick: (Boolean) -> Unit,
+    onReferenceClick: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -103,7 +112,14 @@ fun AssemblyCardContent(
             .align(Alignment.CenterHorizontally)
         )
 
-        AssemblyFooter(breakpoint = breakpoint)
+        AssemblyFooter(
+            breakpoint = breakpoint,
+            isMyFavorite = isMyFavorite,
+            favoriteCount = assembly.favoriteCount,
+            referenceCount = 0, // TODO assembly.referenceCount,
+            onFavoriteClick = onFavoriteClick,
+            onReferenceClick = onReferenceClick
+        )
     }
 }
 
@@ -199,7 +215,12 @@ fun AssemblyMain(
 
 @Composable
 fun AssemblyFooter(
-    breakpoint: Breakpoint
+    breakpoint: Breakpoint,
+    isMyFavorite: Boolean,
+    favoriteCount: Int,
+    referenceCount: Int,
+    onFavoriteClick: (Boolean) -> Unit,
+    onReferenceClick: () -> Unit,
 ) {
     Row(
         modifier = Modifier
@@ -207,6 +228,13 @@ fun AssemblyFooter(
             .padding(topBottom = 8.px),
         horizontalArrangement = Arrangement.Center
     ) {
-        ImpressionIcons(breakpoint = breakpoint)
+        ImpressionIcons(
+            breakpoint = breakpoint,
+            isMyFavorite = isMyFavorite,
+            favoriteCount = favoriteCount,
+            referenceCount = referenceCount,
+            onFavoriteClick = onFavoriteClick,
+            onReferenceClick = onReferenceClick,
+        )
     }
 }

--- a/site/src/jsMain/kotlin/bbee/developer/jp/assemble_pc/components/widgets/ImpressionIcons.kt
+++ b/site/src/jsMain/kotlin/bbee/developer/jp/assemble_pc/components/widgets/ImpressionIcons.kt
@@ -1,6 +1,11 @@
 package bbee.developer.jp.assemble_pc.components.widgets
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import bbee.developer.jp.assemble_pc.models.Theme
 import bbee.developer.jp.assemble_pc.util.Const
 import bbee.developer.jp.assemble_pc.util.mediumSize
 import com.varabyte.kobweb.compose.css.Cursor
@@ -11,15 +16,19 @@ import com.varabyte.kobweb.compose.ui.Alignment
 import com.varabyte.kobweb.compose.ui.Modifier
 import com.varabyte.kobweb.compose.ui.attrsModifier
 import com.varabyte.kobweb.compose.ui.modifiers.classNames
+import com.varabyte.kobweb.compose.ui.modifiers.color
 import com.varabyte.kobweb.compose.ui.modifiers.cursor
+import com.varabyte.kobweb.compose.ui.modifiers.fillMaxHeight
 import com.varabyte.kobweb.compose.ui.modifiers.fontFamily
 import com.varabyte.kobweb.compose.ui.modifiers.fontSize
 import com.varabyte.kobweb.compose.ui.modifiers.fontWeight
 import com.varabyte.kobweb.compose.ui.modifiers.margin
 import com.varabyte.kobweb.compose.ui.modifiers.onClick
+import com.varabyte.kobweb.compose.ui.modifiers.padding
 import com.varabyte.kobweb.compose.ui.modifiers.width
 import com.varabyte.kobweb.silk.components.icons.fa.FaShareFromSquare
 import com.varabyte.kobweb.silk.components.icons.fa.FaThumbsUp
+import com.varabyte.kobweb.silk.components.icons.fa.IconSize
 import com.varabyte.kobweb.silk.components.icons.fa.IconStyle
 import com.varabyte.kobweb.silk.components.navigation.Link
 import com.varabyte.kobweb.silk.components.style.breakpoint.Breakpoint
@@ -28,46 +37,65 @@ import org.jetbrains.compose.web.css.px
 
 @Composable
 fun ImpressionIcons(
-    breakpoint: Breakpoint
+    breakpoint: Breakpoint,
+    isMyFavorite: Boolean,
+    favoriteCount: Int,
+    referenceCount: Int,
+    onFavoriteClick: (Boolean) -> Unit,
+    onReferenceClick: () -> Unit
 ) {
     Row(
-        modifier = Modifier.width(240.px),
+        modifier = Modifier.fillMaxHeight().width(240.px),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {
         Row(
             modifier = Modifier
+                .fillMaxHeight()
                 .cursor(Cursor.Pointer)
-                .onClick { },
+                .onClick { onFavoriteClick(isMyFavorite) },
             verticalAlignment = Alignment.CenterVertically
         ) {
-            FaThumbsUp(style = IconStyle.FILLED)
+            FaThumbsUp(
+                modifier = Modifier
+                    .padding(bottom = 2.px)
+                    .color(if (isMyFavorite) Theme.RED.rgb else Theme.DARK_GRAY.rgb),
+                style = IconStyle.FILLED,
+                size = IconSize.LG
+            )
 
             SpanText(
                 modifier = Modifier
-                    .margin(2.px)
+                    .align(Alignment.CenterVertically)
+                    .margin(left = 4.px)
                     .fontFamily(Const.FONT_FAMILY)
                     .fontSize(breakpoint.mediumSize())
-                    .fontWeight(FontWeight.Bold),
-                text = "100"
+                    .fontWeight(FontWeight.Bold)
+                    .color(if (isMyFavorite) Theme.RED.rgb else Theme.DARK_GRAY.rgb),
+                text = favoriteCount.toString()
             )
         }
 
         Row(
             modifier = Modifier
                 .cursor(Cursor.Pointer)
-                .onClick { },
+                .onClick { onReferenceClick() },
             verticalAlignment = Alignment.CenterVertically
         ) {
-            FaShareFromSquare(style = IconStyle.FILLED)
+            FaShareFromSquare(
+                modifier = Modifier.color(Theme.DARK_GRAY.rgb),
+                style = IconStyle.FILLED,
+                size = IconSize.LG
+            )
 
             SpanText(
                 modifier = Modifier
-                    .margin(2.px)
+                    .margin(left = 4.px)
                     .fontFamily(Const.FONT_FAMILY)
                     .fontSize(breakpoint.mediumSize())
-                    .fontWeight(FontWeight.Bold),
-                text = "100"
+                    .fontWeight(FontWeight.Bold)
+                    .color(Theme.DARK_GRAY.rgb),
+                text = referenceCount.toString()
             )
         }
 

--- a/site/src/jsMain/kotlin/bbee/developer/jp/assemble_pc/pages/Index.kt
+++ b/site/src/jsMain/kotlin/bbee/developer/jp/assemble_pc/pages/Index.kt
@@ -2,16 +2,20 @@ package bbee.developer.jp.assemble_pc.pages
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import bbee.developer.jp.assemble_pc.components.sections.Header
-import bbee.developer.jp.assemble_pc.components.sections.Advertisement
-import bbee.developer.jp.assemble_pc.firebase.auth
-import bbee.developer.jp.assemble_pc.util.signInAnonymous
-import com.varabyte.kobweb.compose.foundation.layout.Arrangement
+import bbee.developer.jp.assemble_pc.components.layouts.CommonLayout
+import bbee.developer.jp.assemble_pc.components.widgets.AssemblyCard
+import bbee.developer.jp.assemble_pc.models.Assembly
+import bbee.developer.jp.assemble_pc.models.AssemblyId
+import bbee.developer.jp.assemble_pc.util.IsUserLoggedIn
+import bbee.developer.jp.assemble_pc.util.addFavoriteAssembly
+import bbee.developer.jp.assemble_pc.util.favoriteUpdate
+import bbee.developer.jp.assemble_pc.util.getMyFavoriteAssemblyIdList
+import bbee.developer.jp.assemble_pc.util.getPublishedAssemblies
+import bbee.developer.jp.assemble_pc.util.removeFavoriteAssembly
 import com.varabyte.kobweb.compose.foundation.layout.Column
-import com.varabyte.kobweb.compose.foundation.layout.Row
 import com.varabyte.kobweb.compose.ui.Alignment
 import com.varabyte.kobweb.compose.ui.Modifier
 import com.varabyte.kobweb.compose.ui.modifiers.fillMaxSize
@@ -19,7 +23,6 @@ import com.varabyte.kobweb.compose.ui.modifiers.margin
 import com.varabyte.kobweb.core.Page
 import com.varabyte.kobweb.silk.components.style.breakpoint.Breakpoint
 import com.varabyte.kobweb.silk.theme.breakpoint.rememberBreakpoint
-import dev.gitlive.firebase.auth.FirebaseUser
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.web.css.percent
 import org.jetbrains.compose.web.css.px
@@ -27,45 +30,61 @@ import org.jetbrains.compose.web.css.px
 @Page
 @Composable
 fun TopPage() {
-    val scope = rememberCoroutineScope()
     val breakpoint = rememberBreakpoint()
 
-    val user: FirebaseUser? by auth.authStateChanged
-        .collectAsState(initial = null, scope.coroutineContext)
-
-    LaunchedEffect(Unit) {
-        scope.launch {
-            signInAnonymous()
+    IsUserLoggedIn {
+        CommonLayout(breakpoint) {
+            TopContents(breakpoint)
         }
-    }
-
-    Column(modifier = Modifier.fillMaxSize()) {
-        Header(breakpoint)
-        
-        TopContents(breakpoint)
     }
 }
 
 @Composable
 fun TopContents(breakpoint: Breakpoint) {
-    Row(
-        modifier = Modifier.fillMaxSize(),
-        horizontalArrangement = Arrangement.SpaceAround,
-    ) {
-        if (breakpoint >= Breakpoint.XL) Advertisement(modifier = Modifier.margin(right = 16.px))
+    val scope = rememberCoroutineScope()
 
-        Column(
-            modifier = Modifier
-                .fillMaxSize(95.percent)
-                .margin(8.px),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-//            AssemblyCard(breakpoint = breakpoint)
-//            AssemblyCard(breakpoint = breakpoint)
-//            AssemblyCard(breakpoint = breakpoint)
-//            AssemblyCard(breakpoint = breakpoint)
+    val myFavoriteList: MutableList<AssemblyId> = remember { mutableStateListOf() }
+    val assemblies: MutableList<Assembly> = remember { mutableStateListOf() }
+
+    LaunchedEffect(Unit) {
+        scope.launch {
+            myFavoriteList.addAll(getMyFavoriteAssemblyIdList())
+            assemblies.addAll(getPublishedAssemblies(skip = 0))
         }
+    }
 
-        if (breakpoint >= Breakpoint.LG) Advertisement(modifier = Modifier.margin(left = 16.px))
+    Column(
+        modifier = Modifier
+            .fillMaxSize(95.percent)
+            .margin(8.px),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        assemblies.forEach { assembly ->
+            AssemblyCard(
+                breakpoint = breakpoint,
+                assembly = assembly,
+                isMyFavorite = assembly.assemblyId in myFavoriteList,
+                onFavoriteClick = { isFavorite ->
+                    scope.launch {
+                        val aid = assembly.assemblyId
+                        if (isFavorite) {
+                            removeFavoriteAssembly(aid).also { isSuccess ->
+                                if (isSuccess) {
+                                    myFavoriteList.remove(aid)
+                                    assemblies.favoriteUpdate(assemblyId = aid, addCount = -1)
+                                }
+                            }
+                        } else {
+                            addFavoriteAssembly(aid).also { isSuccess ->
+                                if (isSuccess) {
+                                    myFavoriteList.add(aid)
+                                    assemblies.favoriteUpdate(assemblyId = aid, addCount = 1)
+                                }
+                            }
+                        }
+                    }
+                }
+            )
+        }
     }
 }

--- a/site/src/jsMain/kotlin/bbee/developer/jp/assemble_pc/pages/mypage/favorite.kt
+++ b/site/src/jsMain/kotlin/bbee/developer/jp/assemble_pc/pages/mypage/favorite.kt
@@ -1,0 +1,179 @@
+package bbee.developer.jp.assemble_pc.pages.mypage
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import bbee.developer.jp.assemble_pc.components.layouts.CommonMyPageLayout
+import bbee.developer.jp.assemble_pc.components.layouts.TabMenuLayout
+import bbee.developer.jp.assemble_pc.components.widgets.AssemblyCard
+import bbee.developer.jp.assemble_pc.components.widgets.ProfileEdit
+import bbee.developer.jp.assemble_pc.components.widgets.SearchBar
+import bbee.developer.jp.assemble_pc.models.Assembly
+import bbee.developer.jp.assemble_pc.models.AssemblyId
+import bbee.developer.jp.assemble_pc.models.MyTabMenu
+import bbee.developer.jp.assemble_pc.models.Profile
+import bbee.developer.jp.assemble_pc.util.Const
+import bbee.developer.jp.assemble_pc.util.IsUserLoggedIn
+import bbee.developer.jp.assemble_pc.util.addFavoriteAssembly
+import bbee.developer.jp.assemble_pc.util.favoriteUpdate
+import bbee.developer.jp.assemble_pc.util.getMyFavoriteAssemblies
+import bbee.developer.jp.assemble_pc.util.getMyProfile
+import bbee.developer.jp.assemble_pc.util.hugeSize
+import bbee.developer.jp.assemble_pc.util.largeSize
+import bbee.developer.jp.assemble_pc.util.removeFavoriteAssembly
+import bbee.developer.jp.assemble_pc.util.updateMyProfile
+import com.varabyte.kobweb.compose.foundation.layout.Arrangement
+import com.varabyte.kobweb.compose.foundation.layout.Column
+import com.varabyte.kobweb.compose.foundation.layout.Row
+import com.varabyte.kobweb.compose.ui.Alignment
+import com.varabyte.kobweb.compose.ui.Modifier
+import com.varabyte.kobweb.compose.ui.modifiers.fillMaxSize
+import com.varabyte.kobweb.compose.ui.modifiers.fillMaxWidth
+import com.varabyte.kobweb.compose.ui.modifiers.fontFamily
+import com.varabyte.kobweb.compose.ui.modifiers.fontSize
+import com.varabyte.kobweb.compose.ui.modifiers.height
+import com.varabyte.kobweb.compose.ui.modifiers.margin
+import com.varabyte.kobweb.compose.ui.modifiers.padding
+import com.varabyte.kobweb.core.Page
+import com.varabyte.kobweb.silk.components.style.breakpoint.Breakpoint
+import com.varabyte.kobweb.silk.components.text.SpanText
+import com.varabyte.kobweb.silk.theme.breakpoint.rememberBreakpoint
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.web.css.percent
+import org.jetbrains.compose.web.css.px
+
+@Page
+@Composable
+fun FavoritePage() {
+    val breakpoint = rememberBreakpoint()
+    val scope = rememberCoroutineScope()
+
+    var myProfile: Profile? by remember { mutableStateOf(null) }
+
+    var showNameEditPopup by remember { mutableStateOf(false) }
+
+    IsUserLoggedIn {
+        LaunchedEffect(Unit) {
+            scope.launch {
+                myProfile = getMyProfile() ?: Profile()
+            }
+        }
+
+        CommonMyPageLayout(
+            breakpoint = breakpoint,
+            showNameEditPopup = showNameEditPopup,
+            userName = myProfile?.userName ?: "",
+            onDismiss = { showNameEditPopup = false },
+            onUserNamePositiveClick = { newName ->
+                scope.launch {
+                    val email = myProfile?.userEmail
+                    if (updateMyProfile(Profile(userName = newName, userEmail = email))) {
+                        myProfile = Profile(userName = newName, userEmail = email)
+                    }
+                    showNameEditPopup = false
+                }
+            }
+        ) {
+            myProfile?.also {
+                FavoriteContents(
+                    breakpoint = breakpoint,
+                    userName = it.userName ?: "(NO NAME)",
+                    onClick = { showNameEditPopup = true }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun FavoriteContents(
+    breakpoint: Breakpoint,
+    userName: String,
+    onClick: () -> Unit
+) {
+    val scope = rememberCoroutineScope()
+    val assemblies: MutableList<Assembly> = remember { mutableStateListOf() }
+    val myFavoriteList: MutableList<AssemblyId> = remember { mutableStateListOf() }
+
+    LaunchedEffect(Unit) {
+        scope.launch {
+            getMyFavoriteAssemblies(skip = 0)
+                .also {
+                    assemblies.addAll(it)
+                    myFavoriteList.addAll(it.map { it.assemblyId })
+                }
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize(95.percent)
+            .margin(8.px),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(40.px)
+                .padding(24.px),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            ProfileEdit(
+                fontSize = breakpoint.largeSize(),
+                name = userName,
+                onClick = onClick
+            )
+            SearchBar(breakpoint = breakpoint)
+        }
+
+        TabMenuLayout(breakpoint = breakpoint, tabList = MyTabMenu.toTabInfoList()) {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                assemblies.ifEmpty {
+                    SpanText(
+                        modifier = Modifier
+                            .padding(24.px)
+                            .fontFamily(Const.FONT_FAMILY)
+                            .fontSize(breakpoint.hugeSize()),
+                        text = "お気に入りの構成はありません"
+                    )
+                }
+                assemblies.forEach { assembly ->
+                    AssemblyCard(
+                        breakpoint = breakpoint,
+                        assembly = assembly,
+                        isMyFavorite = assembly.assemblyId in myFavoriteList,
+                        onFavoriteClick = { isFavorite ->
+                            scope.launch {
+                                val aid = assembly.assemblyId
+                                if (isFavorite) {
+                                    removeFavoriteAssembly(aid).also { isSuccess ->
+                                        if (isSuccess) {
+                                            myFavoriteList.remove(aid)
+                                            assemblies.favoriteUpdate(assemblyId = aid, addCount = -1)
+                                        }
+                                    }
+                                } else {
+                                    addFavoriteAssembly(aid).also { isSuccess ->
+                                        if (isSuccess) {
+                                            myFavoriteList.add(aid)
+                                            assemblies.favoriteUpdate(assemblyId = aid, addCount = 1)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    )
+                }
+            }
+        }
+    }
+}

--- a/site/src/jsMain/kotlin/bbee/developer/jp/assemble_pc/util/ApiFunctions.kt
+++ b/site/src/jsMain/kotlin/bbee/developer/jp/assemble_pc/util/ApiFunctions.kt
@@ -194,3 +194,83 @@ suspend fun getMyUnpublishedAssemblies(skip: Int): List<Assembly> {
         emptyList()
     }
 }
+
+suspend fun getPublishedAssemblies(skip: Int): List<Assembly> {
+    return runCatching {
+        auth.currentUser?.getIdToken(false)
+            ?.let { token ->
+                window.api.tryGet(
+                    apiPath = "get_published_assemblies?skip=$skip",
+                    headers = getApiHeader(token),
+                )?.decodeToString()?.parseData<List<Assembly>>()
+                    ?: throw IllegalStateException(message = "getPublishedAssemblies() result is null")
+            } ?: throw IllegalStateException(message = "getPublishedAssemblies() user or token is null")
+    }.getOrElse { e ->
+        println(e.message)
+        emptyList()
+    }
+}
+
+suspend fun getMyFavoriteAssemblyIdList(): List<AssemblyId> {
+    return runCatching {
+        auth.currentUser?.getIdToken(false)
+            ?.let { token ->
+                window.api.tryGet(
+                    apiPath = "get_my_favorite_assembly_id_list",
+                    headers = getApiHeader(token),
+                )?.decodeToString()?.parseData<List<AssemblyId>>()
+                    ?: throw IllegalStateException(message = "getMyFavoriteAssemblyIdList() result is null")
+            } ?: throw IllegalStateException(message = "getMyFavoriteAssemblyIdList() user or token is null")
+    }.getOrElse { e ->
+        println(e.message)
+        emptyList()
+    }
+}
+
+suspend fun addFavoriteAssembly(assemblyId: AssemblyId): Boolean {
+    return runCatching {
+        auth.currentUser?.getIdToken(false)
+            ?.let { token ->
+                window.api.tryGet(
+                    apiPath = "add_favorite_assembly?assemblyId=${assemblyId.id}",
+                    headers = getApiHeader(token),
+                )?.decodeToString()?.parseData<Boolean>()
+                    ?: throw IllegalStateException(message = "addFavoriteAssembly() result is null")
+            } ?: throw IllegalStateException(message = "addFavoriteAssembly() user or token is null")
+    }.getOrElse { e ->
+        println(e.message)
+        false
+    }
+}
+
+suspend fun removeFavoriteAssembly(assemblyId: AssemblyId): Boolean {
+    return runCatching {
+        auth.currentUser?.getIdToken(false)
+            ?.let { token ->
+                window.api.tryGet(
+                    apiPath = "remove_favorite_assembly?assemblyId=${assemblyId.id}",
+                    headers = getApiHeader(token),
+                )?.decodeToString()?.parseData<Boolean>()
+                    ?: throw IllegalStateException(message = "removeFavoriteAssembly() result is null")
+            } ?: throw IllegalStateException(message = "removeFavoriteAssembly() user or token is null")
+    }.getOrElse { e ->
+        println(e.message)
+        false
+    }
+}
+
+suspend fun getMyFavoriteAssemblies(skip: Int): List<Assembly> {
+    return runCatching {
+        auth.currentUser?.getIdToken(false)
+            ?.let { token ->
+                window.api.tryGet(
+                    apiPath = "get_my_favorite_assemblies?skip=$skip",
+                    headers = getApiHeader(token),
+                )?.decodeToString()?.parseData<List<Assembly>>()
+                    ?: throw IllegalStateException(message = "getMyFavoriteAssemblies() result is null")
+            } ?: throw IllegalStateException(message = "getMyFavoriteAssemblies() user or token is null")
+    }.getOrElse { e ->
+        println(e.message)
+        emptyList()
+    }
+}

--- a/site/src/jsMain/kotlin/bbee/developer/jp/assemble_pc/util/AssemblyUtil.kt
+++ b/site/src/jsMain/kotlin/bbee/developer/jp/assemble_pc/util/AssemblyUtil.kt
@@ -1,6 +1,7 @@
 package bbee.developer.jp.assemble_pc.util
 
 import bbee.developer.jp.assemble_pc.models.Assembly
+import bbee.developer.jp.assemble_pc.models.AssemblyId
 import bbee.developer.jp.assemble_pc.models.Price
 
 fun Assembly.totalAmount(): Price =
@@ -11,3 +12,11 @@ fun Assembly.totalAmount(): Price =
             .map { it.item.price }
             .reduce { acc, price -> acc + price }
     }
+
+fun MutableList<Assembly>.favoriteUpdate(assemblyId: AssemblyId, addCount: Int) {
+    find { it.assemblyId == assemblyId }
+        ?.also { assembly ->
+            val newCount = (assembly.favoriteCount + addCount).coerceAtLeast(0)
+            this[indexOf(assembly)] = assembly.copy(favoriteCount = newCount)
+        }
+}

--- a/site/src/jvmMain/kotlin/bbee/developer/jp/assemble_pc/api/AssemblyApi.kt
+++ b/site/src/jvmMain/kotlin/bbee/developer/jp/assemble_pc/api/AssemblyApi.kt
@@ -43,8 +43,9 @@ suspend fun createAssembly(context: ApiContext) {
                         referenceAssemblyId = refId?.toIntOrNull()?.let { AssemblyId(it) } ,
                         published = false,
                         publishedDate = currentDateTime.toDateTimeString(),
-                        assemblyDetails = emptyList()
-                    ).let { assembly ->
+                        assemblyDetails = emptyList(),
+                        favoriteCount = 0,
+                    ).also { assembly ->
                         data.getValue<H2DB>().addAssembly(uid, assembly).also { isSuccess ->
                             if (isSuccess) {
                                 getCurrentAssembly(context = context)
@@ -199,4 +200,40 @@ suspend fun getMyUnpublishedAssemblies(context: ApiContext) {
             }
         }
     }.onFailureCommonResponse(context = context, functionName = "getMyPublishedAssemblies")
+}
+
+@Api(routeOverride = "get_published_assemblies")
+suspend fun getPublishedAssemblies(context: ApiContext) {
+    context.runCatching {
+        getUid().also { uid ->
+            req.params.getOrDefault("skip", "0").toLongOrNull().also { skip ->
+                data.getValue<H2DB>()
+                    .getAssemblies(uid = uid, skip = skip ?: 0L, own = false, published = true)
+                    .also { result -> res.setBody(result) }
+            }
+        }
+    }.onFailureCommonResponse(context = context, functionName = "getPublishedAssemblies")
+}
+
+@Api(routeOverride = "get_my_favorite_assembly_id_list")
+suspend fun getMyFavoriteAssemblyIdList(context: ApiContext) {
+    context.runCatching {
+        getUid().also { uid ->
+            data.getValue<H2DB>().getMyFavoriteAssemblyIdList(uid)
+                .also { list -> res.setBody(list) }
+        }
+    }.onFailureCommonResponse(context = context, functionName = "getMyFavoriteAssemblyIdList")
+}
+
+@Api(routeOverride = "get_my_favorite_assemblies")
+suspend fun getMyFavoriteAssemblies(context: ApiContext) {
+    context.runCatching {
+        getUid().also { uid ->
+            req.params.getOrDefault("skip", "0").toLongOrNull().also { skip ->
+                data.getValue<H2DB>()
+                    .getAssemblies(uid = uid, skip = skip ?: 0L, own = false, published = true, favoriteOnly = true)
+                    .also { list -> res.setBody(list) }
+            }
+        }
+    }.onFailureCommonResponse(context = context, functionName = "getMyFavoriteAssemblies")
 }

--- a/site/src/jvmMain/kotlin/bbee/developer/jp/assemble_pc/api/FavoriteApi.kt
+++ b/site/src/jvmMain/kotlin/bbee/developer/jp/assemble_pc/api/FavoriteApi.kt
@@ -1,0 +1,38 @@
+package bbee.developer.jp.assemble_pc.api
+
+import bbee.developer.jp.assemble_pc.api.util.getUid
+import bbee.developer.jp.assemble_pc.api.util.onFailureCommonResponse
+import bbee.developer.jp.assemble_pc.api.util.setBody
+import bbee.developer.jp.assemble_pc.database.H2DB
+import bbee.developer.jp.assemble_pc.models.AssemblyId
+import com.varabyte.kobweb.api.Api
+import com.varabyte.kobweb.api.ApiContext
+import com.varabyte.kobweb.api.data.getValue
+
+@Api(routeOverride = "add_favorite_assembly")
+suspend fun addFavoriteAssembly(context: ApiContext) {
+    context.runCatching {
+        getUid().also { uid ->
+            req.params["assemblyId"]?.toIntOrNull()?.also { reqId ->
+                AssemblyId(reqId).also { assemblyId ->
+                    data.getValue<H2DB>().addFavoriteAssembly(uid, assemblyId)
+                        .also { isSuccess -> res.setBody(isSuccess) }
+                }
+            } ?: throw IllegalArgumentException("Invalid assemblyId specification")
+        }
+    }.onFailureCommonResponse(context = context, functionName = "addFavoriteAssembly")
+}
+
+@Api(routeOverride = "remove_favorite_assembly")
+suspend fun removeFavoriteAssembly(context: ApiContext) {
+    context.runCatching {
+        getUid().also { uid ->
+            req.params["assemblyId"]?.toIntOrNull()?.also { reqId ->
+                AssemblyId(reqId).also { assemblyId ->
+                    data.getValue<H2DB>().removeFavoriteAssembly(uid, assemblyId)
+                        .also { isSuccess -> res.setBody(isSuccess) }
+                }
+            } ?: throw IllegalArgumentException("Invalid assemblyId specification")
+        }
+    }.onFailureCommonResponse(context = context, functionName = "removeFavoriteAssembly")
+}

--- a/site/src/jvmMain/kotlin/bbee/developer/jp/assemble_pc/database/H2Repository.kt
+++ b/site/src/jvmMain/kotlin/bbee/developer/jp/assemble_pc/database/H2Repository.kt
@@ -20,5 +20,8 @@ interface H2Repository {
     suspend fun updateAssemblyDetail(detailId: DetailId, detail: AssemblyDetail): Boolean
     suspend fun deleteAssemblyDetails(detailIds: List<DetailId>): Boolean
     suspend fun getItems(category: ItemCategory, skip: Long): List<Item>
-    suspend fun getAssemblies(uid: String, skip: Long, own: Boolean, published: Boolean): List<Assembly>
+    suspend fun getAssemblies(uid: String, skip: Long, own: Boolean, published: Boolean, favoriteOnly: Boolean = false): List<Assembly>
+    suspend fun addFavoriteAssembly(uid: String, aid: AssemblyId): Boolean
+    suspend fun removeFavoriteAssembly(uid: String, aid: AssemblyId): Boolean
+    suspend fun getMyFavoriteAssemblyIdList(uid: String): List<AssemblyId>
 }

--- a/site/src/jvmMain/kotlin/bbee/developer/jp/assemble_pc/database/entity/Entity.kt
+++ b/site/src/jvmMain/kotlin/bbee/developer/jp/assemble_pc/database/entity/Entity.kt
@@ -16,6 +16,8 @@ val TABLES = arrayOf(
     FavoriteMakers,
     FavoriteAssemblies
 )
+const val CREATE_FAV_ASSEM_VIEW: String = """CREATE VIEW IF NOT EXISTS FAVORITE_ASSEMBLIES_VIEW AS (SELECT ASSEMBLY_ID, COUNT(ASSEMBLY_ID) AS FAVORITE_COUNT FROM FAVORITEASSEMBLIES GROUP BY ASSEMBLY_ID);"""
+const val CREATE_REF_ASSEM_VIEW: String = """CREATE VIEW IF NOT EXISTS REFERENCE_ASSEMBLIES_VIEW AS (SELECT REFERENCE_ASSEMBLY_ID AS ASSEMBLY_ID, COUNT(REFERENCE_ASSEMBLY_ID) AS REFERENCE_COUNT FROM ASSEMBLIES WHERE REFERENCE_ASSEMBLY_ID IS NOT NULL GROUP BY REFERENCE_ASSEMBLY_ID);"""
 
 object Users : Table() {
     val userId: Column<String> = varchar("USER_ID", 36)
@@ -128,4 +130,14 @@ object FavoriteAssemblies : Table() {
     val updatedAt: Column<LocalDateTime> = datetime("UPDATED_AT")
 
     override val primaryKey = PrimaryKey(firstColumn = id, name = "PK_FAVORITE_ASSEMBLIES_ID")
+}
+
+object FavoriteAssembliesView : Table("FAVORITE_ASSEMBLIES_VIEW") {
+    val assemblyId: Column<Int> = integer("ASSEMBLY_ID")
+    val favoriteCount: Column<Long> = long("FAVORITE_COUNT")
+}
+
+object ReferenceAssembliesView : Table("REFERENCE_ASSEMBLIES_VIEW") {
+    val assemblyId: Column<Int> = integer("ASSEMBLY_ID")
+    val referenceCount: Column<Long> = long("REFERENCE_COUNT")
 }


### PR DESCRIPTION
- トップページに他ユーザーの公開構成を表示
- いいね数の反映のためのAPIとUI作成
- いいねしたユーザーと構成のペアテーブル FavoriteAssemblies から、構成ごとのいいね数の FavoriteAssembliesView ビューテーブルを作成
- マイページのお気に入りタブページで、自分がいいねした構成を取得するAPIとUIを作成